### PR TITLE
fix(content-pages): add file translations - INNO-924

### DIFF
--- a/framework/templates/ema-content-pages/ema-content-pages.config.js
+++ b/framework/templates/ema-content-pages/ema-content-pages.config.js
@@ -398,9 +398,34 @@ module.exports = {
         disabled: true,
       },
     ],
+    files: {
+      variant: 'translation',
+      title: 'File title example',
+      language: 'English',
+      meta: '213.25 kB - PDF - 4 pages',
+      button_label: 'Download',
+      icon: 'file',
+      translations: [
+        {
+          title: 'Titre du fichier',
+          meta: '228.84 kB - PDF - 4 pages',
+        },
+        {
+          title: 'Dateititel',
+          meta: '232.12 kB - PDF - 4 pages',
+        },
+        {
+          title: 'Файл Заглавие',
+          meta: '257.54 kB - PDF - 4 pages',
+        },
+      ],
+      translations_label: 'Available languages (3)',
+      translations_tooltip: 'Click to see translations',
+    },
     _demo: {
       scripts: `document.addEventListener('DOMContentLoaded', function () {
         ECL.megamenu();
+        ECL.initExpandables('#translations-expand-button');
       });`,
     },
   },

--- a/framework/templates/ema-content-pages/ema-content-pages.twig
+++ b/framework/templates/ema-content-pages/ema-content-pages.twig
@@ -99,6 +99,8 @@
             } %}
           </div>
         </form>
+
+        {% include '@ec-europa/ecl-files' with files %}
       </section>
     </div>
   </div>


### PR DESCRIPTION
Update content page template to add example of translations to one of the files (at the end of the page).
Should be inspired by and/or based on https://ec-europa.github.io/europa-component-library/components/detail/ecl-files--translations